### PR TITLE
Work around weird zcat(1) behaviour on Mac OS

### DIFF
--- a/script/opan
+++ b/script/opan
@@ -143,7 +143,7 @@ sub do_fetch {
         ->res->body
   );
   path('pans/upstream/index')->spurt(
-    scalar capture zcat => 'pans/upstream/index.gz'
+    scalar capture qw(gzip -dc), 'pans/upstream/index.gz'
   );
 }
 


### PR DESCRIPTION
The system /usr/bin/zcat on Mac OS replicates an oddity of traditional pre-gzip Unix compress(1): it assumes it should append ".Z" to the name of the file you give it (which means that it then fails when that file doesn't exist). So just use "gzip -dc" directly on all platforms.