### PR TITLE
Implement upload functionality and recurring pull

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for App-opan
 
+  - Refactor to use more Mojo::File
+  - Added token protected upload endpoint with CPAN::Uploader compat
+  - Added periodic updater.
+
 0.002002 - 2017-05-22
   - port the tests to new Mojo::File API as well so it still installs
 

--- a/script/opan
+++ b/script/opan
@@ -9,12 +9,9 @@ our $VERSION = '0.002002';
 use Dist::Metadata;
 use File::Open qw(fopen);
 use List::UtilsBy qw(sort_by);
-use File::Path qw(mkpath);
 use IPC::System::Simple qw(capture);
 use Mojo::Util qw(monkey_patch);
 use Mojo::File qw(path);
-use File::Spec;
-use File::Copy qw(copy);
 use Import::Into;
 
 sub packages_header {
@@ -130,8 +127,7 @@ my @pan_names = qw(upstream custom pinset combined nopin);
 
 sub do_init {
   my ($app) = @_;
-  mkpath('pans');
-  mkpath("pans/$_/dists") for @pan_names;
+  path("pans/$_/dists")->make_path for @pan_names;
   write_packages_file("pans/$_/index", []) for qw(custom pinset);
   do_pull($app);
 }
@@ -170,9 +166,9 @@ sub do_pull {
 
 sub do_add {
   my ($app, $path) = @_;
-  my (undef, $dir, $file) = File::Spec->splitpath($path);
-  mkpath(my $pan_dir = 'pans/custom/dists/M/MY/MY');
-  copy($path, my $pan_path = File::Spec->catdir($pan_dir, $file))
+  $path=path($path);
+  my $pan_dir = path('pans/custom/dists/M/MY/MY')->make_path;
+  $path->copy_to(my $pan_path = $pan_dir->child($path->basename))
     or die "Failed to copy ${path} into custom pan: $!";
   add_dist_to_index('pans/custom/index', $pan_path);
 }
@@ -185,9 +181,9 @@ sub do_unadd {
 sub do_pin {
   my ($app, $path) = @_;
   $path =~ /^(([A-Z])[A-Z])[A-Z]/ and $path = join('/', $2, $1, $path);
-  my (undef, $dir, $file) = File::Spec->splitpath($path);
-  mkpath("pans/pinset/dists/${dir}");
-  path(my $pan_path = "pans/pinset/dists/${path}")->spurt(
+  $path=path($path);
+  path("pans/pinset/dists/")->child($path->dirname)->make_path;
+  my $pan_path=path("pans/pinset/dists/${path}")->spurt(
     $app->ua->get($app->cpan_url.'authors/id/'.$path)->res->body
   );
   add_dist_to_index('pans/pinset/index', $pan_path);

--- a/script/opan
+++ b/script/opan
@@ -14,6 +14,8 @@ use Mojo::Util qw(monkey_patch);
 use Mojo::File qw(path);
 use Import::Into;
 
+our %TOKENS = map { $_=>1 } split/:/, $ENV{OPAN_AUTH_TOKENS} || '';
+
 sub packages_header {
   my ($count) = @_;
   (my $str = <<"  HEADER") =~ s/^    //mg;
@@ -165,8 +167,8 @@ sub do_pull {
 }
 
 sub do_add {
-  my ($app, $path) = @_;
-  $path=path($path);
+  my ($app, $path_arg) = @_;
+  my $path = path($path_arg);
   my $pan_dir = path('pans/custom/dists/M/MY/MY')->make_path;
   $path->copy_to(my $pan_path = $pan_dir->child($path->basename))
     or die "Failed to copy ${path} into custom pan: $!";
@@ -179,11 +181,11 @@ sub do_unadd {
 }
 
 sub do_pin {
-  my ($app, $path) = @_;
-  $path =~ /^(([A-Z])[A-Z])[A-Z]/ and $path = join('/', $2, $1, $path);
-  $path=path($path);
+  my ($app, $path_arg) = @_;
+  $path_arg =~ /^(([A-Z])[A-Z])[A-Z]/ and $path_arg = join('/', $2, $1, $path_arg);
+  my $path = path($path_arg);
   path("pans/pinset/dists/")->child($path->dirname)->make_path;
-  my $pan_path=path("pans/pinset/dists/${path}")->spurt(
+  my $pan_path = path("pans/pinset/dists/${path}")->spurt(
     $app->ua->get($app->cpan_url.'authors/id/'.$path)->res->body
   );
   add_dist_to_index('pans/pinset/index', $pan_path);
@@ -267,6 +269,27 @@ foreach my $cmd (
 }
 
 use Mojolicious::Lite;
+
+Mojo::IOLoop->recurring(600 => sub { do_pull(app); }) if $ENV{OPAN_RECURRING_PULL};
+
+post "/upload" => sub {
+  my $c = shift;
+  unless ($TOKENS{$c->req->url->to_abs->password || ""}) {
+    $c->res->headers->www_authenticate("Basic realm=opan");
+    return $c->render(status => 401, text => "Token missing or not found\n");
+  }
+  my $upload = $c->req->upload('dist') || $c->req->upload('pause99_add_uri_httpupload')
+    or return $c->render(status => 400, text => "dist file missing\n");
+  my $pan_dir = path('pans/custom/dists/M/MY/MY')->make_path;
+  $upload->move_to(my $pan_path = $pan_dir->child($upload->filename))
+    or $c->render(
+    status => 500,
+    text   => "Failed to move ${upload} into custom pan: $!\n"
+    );
+  add_dist_to_index('pans/custom/index', $pan_path);
+  do_merge(app);
+  $c->render(text => "$pan_path Added to opan\n");
+};
 
 push(@{app->commands->namespaces}, 'App::opan::Command');
 
@@ -601,6 +624,18 @@ Since this can modify your opan config, it's only enabled if the environment
 variable C<OPAN_AUTOPIN> is set to a true value (calling the L</cpanm> or
 L</carton> commands with C<--autopin> sets this for you, because you already
 specified you wanted that).
+
+=head2 uploads
+
+To enable the /upload endpoint, set the ENV var OPAN_AUTH_TOKENS to a colon
+separated list of accepted tokens for uploads. This will allow a post with a
+'file' upload argument, checking http basic auth password against the provided
+auth tokens.
+
+=head2 recurring pull
+
+Set ENV OPAN_RECURRING_PULL to a true value to make opan automatically pull
+from upstream every 600 seconds
 
 =head1 AUTHOR
 

--- a/t/upload.t
+++ b/t/upload.t
@@ -1,0 +1,38 @@
+use Test::Mojo;
+use Test::More;
+
+use FindBin;
+use File::chdir;
+use Mojo::File qw/tempdir path/;
+
+my $tempdir = tempdir(CLEANUP => 1);
+
+BEGIN { $ENV{OPAN_AUTH_TOKENS} = 'abc:bcd'; }
+
+require "$FindBin::Bin/../script/opan";
+
+local $CWD = $tempdir;
+my $t = Test::Mojo->new;
+$t->app->start('init');
+
+$t->post_ok('/upload')->status_is('401');
+$t->post_ok('/upload', {Authorization => "Basic OmFiYw=="})->status_is('400');
+my $upload = {dist => {content => 'HELLO', filename => 'world.tgz'}};
+$t->post_ok('/upload', {Authorization => "Basic OmFiYw=="}, form => $upload)->status_is('200');
+my $f=$tempdir->child('test')->spurt('TEST');
+my $url=$t->ua->server->url->path('upload')->to_abs.'';
+
+if (eval 'use CPAN::Uploader; 1') {
+  Mojo::IOLoop->subprocess(sub {
+          my $sub = shift;
+          return CPAN::Uploader->upload_file($f.'', {upload_uri => $url, user => 'foo', password => 'abc', debug => 1 });
+      }, sub {
+          my ($sub,$ret) = @_;
+          ok(!$ret, 'no return is good return');
+          Mojo::IOLoop->stop;
+      });
+  Mojo::IOLoop->start;
+  ok( -s 'pans/custom/dists/M/MY/MY/test', 'file got uploaded');
+}
+
+done_testing


### PR DESCRIPTION
This  pull request adds CPAN Uploader functionality to OPAN to allow releases using CPAN::Uploader just like when releasing to PAUSE. This functionality can also be used directly with curl like this:

```curl -F "dist=@$(realpath MyApp-0.1.tar.gz)" "http://foo:mytoken@myopan.example.com/upload"```

This change also makes OPAN automatically do a pull every 600 seconds if ENV variable OPAN_RECURRING_PULL is set. 