### PR TITLE
Improved help for end user

### DIFF
--- a/script/opan
+++ b/script/opan
@@ -16,6 +16,14 @@ use Import::Into;
 
 our %TOKENS = map { $_=>1 } split/:/, $ENV{OPAN_AUTH_TOKENS} || '';
 
+sub cpan_fetch {
+  my $app = shift;
+  my $url = Mojo::URL->new(shift)->to_abs($app->cpan_url);
+  my $tx = $app->ua->get($url);
+  return $tx->res unless my $err = $tx->error;
+  die sprintf "%s %s: %s\n", $tx->req->method, $url, $err->{message};
+}
+
 sub packages_header {
   my ($count) = @_;
   (my $str = <<"  HEADER") =~ s/^    //mg;
@@ -137,8 +145,7 @@ sub do_init {
 sub do_fetch {
   my ($app) = @_;
   path('pans/upstream/index.gz')->spurt(
-    $app->ua->get($app->cpan_url.'modules/02packages.details.txt.gz')
-        ->res->body
+    cpan_fetch($app, 'modules/02packages.details.txt.gz')->body
   );
   path('pans/upstream/index')->spurt(
     scalar capture qw(gzip -dc), 'pans/upstream/index.gz'
@@ -184,11 +191,9 @@ sub do_pin {
   my ($app, $path_arg) = @_;
   $path_arg =~ /^(([A-Z])[A-Z])[A-Z]/ and $path_arg = join('/', $2, $1, $path_arg);
   my $path = path($path_arg);
+  my $res = cpan_fetch($app, "authors/id/$path");
   path("pans/pinset/dists/")->child($path->dirname)->make_path;
-  my $pan_path = path("pans/pinset/dists/${path}")->spurt(
-    $app->ua->get($app->cpan_url.'authors/id/'.$path)->res->body
-  );
-  add_dist_to_index('pans/pinset/index', $pan_path);
+  add_dist_to_index('pans/pinset/index', path("pans/pinset/dists/$path")->spurt($res->body));
 }
 
 sub do_unpin {
@@ -293,7 +298,7 @@ post "/upload" => sub {
 
 push(@{app->commands->namespaces}, 'App::opan::Command');
 
-helper cpan_url => sub { $ENV{OPAN_MIRROR} || 'http://www.cpan.org/' };
+helper cpan_url => sub { Mojo::URL->new($ENV{OPAN_MIRROR} || 'http://www.cpan.org/') };
 
 my $nopin_static = Mojolicious::Static->new(
   paths => [ 'pans/custom/dists' ]

--- a/script/opan
+++ b/script/opan
@@ -44,6 +44,24 @@ sub extract_provides_from_tarball {
   Dist::Metadata->new(file => $tarball)->package_versions;
 }
 
+sub pod_section {
+  my ($cmd, $for_description) = @_;
+  my $fh = fopen __FILE__;
+
+  my $pod = '';
+  while (<$fh>) { /^=head3 $cmd\s*$/ && last }
+  while (<$fh>) { /^=head/ && last || ($pod .= $_) }
+
+  if ($for_description) {
+    $pod = $pod =~ m!\n(\S+.*?\.)(?:\s|$)!s ? $1 : "$0 $cmd --help for more info";
+    $pod =~ s![\n\r]+! !g;
+    $pod =~ s![\s\.]+$!!;
+  }
+
+  $pod =~ s!\b[CIL]<\/?([^>]+)\>!$1!g; # Remove C<...> pod notation
+  return $pod;
+}
+
 sub provides_to_packages_entries {
   my ($path, $provides) = @_;
   # <@mst> ok, I officially have no idea what order 02packages is actually in
@@ -269,6 +287,8 @@ foreach my $cmd (
   my $pkg = "App::opan::Command::${cmd}";
   my $code = __PACKAGE__->can("do_${cmd}");
   Mojo::Base->import::into($pkg, 'Mojolicious::Command');
+  monkey_patch $pkg, description => sub { pod_section($cmd, 1) };
+  monkey_patch $pkg, usage => sub { pod_section($cmd, 0) };
   monkey_patch $pkg,
     run => sub { my $self = shift; $code->($self->app, @_) };
 }
@@ -514,7 +534,7 @@ Rebuilds the L</combined> and L</nopin> PANs' index files.
 
   opan pull
 
-Does an L</fetch> then an L</merge>. There's no equivalent for others,
+Does a L</fetch> and then a L</merge>. There's no equivalent for others,
 on the assumption what you'll do is roughly L</pin>, L</add>, L</unpin>,
 L</unadd>, ... repeat ..., L</pull>.
 
@@ -553,7 +573,7 @@ Runs a request against the opan URL space using L<Mojolicious::Command::get>.
 
   opan cpanm --installdeps .
 
-Starts a temporary server process and runs
+Starts a temporary server process and runs cpanm.
 
   cpanm --mirror http://localhost:<port>/combined/ --mirror-only <your args here>
 
@@ -569,7 +589,7 @@ to request a specific PAN.
 
   opan carton install
 
-Starts a temporary server process and runs
+Starts a temporary server process and runs carton.
 
   PERL_CARTON_MIRROR=http://localhost:<port>/combined/ carton <your args here>
 

--- a/t/help.t
+++ b/t/help.t
@@ -1,0 +1,30 @@
+use strictures 2;
+use Test::More;
+
+my $app = require "./script/opan";
+
+my %descriptions = (
+  add => qr{Imports a distribution.*MY},
+  carton => qr{Starts a temporary server.*carton},
+  cpanm => qr{Starts a temporary server process and runs cpanm},
+  fetch => qr{Fetches 02packages.*PAN},
+  init => qr{Creates a pans/ directory.*},
+  merge => qr{Rebuilds the combined and nopin},
+  pin => qr{Fetches the file .* pinset},
+  pull => qr{Does a fetch and then a merge},
+  purge => qr{Deletes all files},
+  purgelist => qr{Outputs a list of all non-indexed dists in pinset and custom},
+  unadd => qr{custom PAN index[\s\n]+and removes the entries},
+  unpin => qr{pinset PAN index[\s\n]+and removes the entries},
+);
+
+for my $cmd (
+  qw(init fetch add unadd pin unpin merge pull purgelist purge cpanm carton)
+) {
+  my $pkg = "App::opan::Command::${cmd}";
+  like $pkg->new->usage, qr/^\s+opan $cmd.*$descriptions{$cmd}/s, "$cmd usage";
+  like $pkg->new->description, $descriptions{$cmd}, "$cmd description";
+  unlike $pkg->new->description, qr{[<>]}, "$cmd description without pod characters";
+}
+
+done_testing;

--- a/t/pan.t
+++ b/t/pan.t
@@ -91,6 +91,9 @@ foreach my $pan (qw(upstream nopin combined)) {
   );
 }
 
+eval { run(pin => 'X/Y-0.00.tar.gz') };
+like $@, qr{^GET .*X/Y-0\.00\.tar\.gz: Not Found\n}, 'invalid pin distro';
+
 run(pin => 'MSCHWERN/AAAAAAAAA-1.00.tar.gz');
 
 ok(


### PR DESCRIPTION
This pull requests has two commits:

* 9af52a1 is to inform the user in case opan is unable to communicate with the `cpan_url`. I ran into a rather confusing situation when I forgot to set `MOJO_PROXY=1`. Adding the error handling will make it easier to spot those cases imo.
* bb8a6c8 will fetch the pod and use it when you run `opan --help` and `opan purge --help` (or any other sub command).

Let me know if you want this as two different pull requests. I made it into one, since I think they are related in the sense that they both aim to help the user.

I'm also not sure what the programming style is supposed to be, so I just made some guesses.

Looking forward to your feedback :)