### PR TITLE
Avoid . in inc

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,7 +4,7 @@ use ExtUtils::MakeMaker;
 
 use 5.008000;
 
-(do 'maint/Makefile.PL.include' or die $@) unless -f 'META.yml';
+(do './maint/Makefile.PL.include' or die $@) unless -f 'META.yml';
 
 WriteMakefile(
   NAME => 'App::opan',


### PR DESCRIPTION
This PR incorporates p5sagit/Distar@00588dd to avoid needing `.` in `@INC` and/or `PERL_USE_UNSAFE_INC` on >=5.28